### PR TITLE
add marshaling methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+/ksuid
+
+# Emacs
+*~
+
+# govendor
+/vendor/*/

--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -1,23 +1,84 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
+	"flag"
 	"fmt"
+	"html/template"
+	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/segmentio/ksuid"
 )
 
-const usage = `
-Usage: ksuid <ksuid>
-       ksuid
-			 ksuid --help
+var (
+	count   int
+	format  string
+	tpltxt  string
+	verbose bool
+)
 
-Generates and inspects KSUIDs
-`
+func init() {
+	flag.IntVar(&count, "n", 1, "Number of KSUIDs to generate when called with no other arguments.")
+	flag.StringVar(&format, "f", "inspect", "One of inspect, time, timestamp, payload, raw, or template.")
+	flag.StringVar(&tpltxt, "t", "", "The Go template used to format the output.")
+	flag.BoolVar(&verbose, "v", false, "Turn on verbose mode.")
+}
 
-const inspectFormat = `
+func main() {
+	flag.Parse()
+	args := flag.Args()
+
+	var print func(ksuid.KSUID)
+	switch format {
+	case "inspect":
+		print = printInspect
+	case "time":
+		print = printTime
+	case "timestamp":
+		print = printTimestamp
+	case "payload":
+		print = printPayload
+	case "raw":
+		print = printRaw
+	case "template":
+		print = printTemplate
+	default:
+		fmt.Println("Bad formatting function:", format)
+		os.Exit(1)
+	}
+
+	if len(args) == 0 {
+		for i := 0; i < count; i++ {
+			fmt.Println(ksuid.New())
+		}
+		os.Exit(0)
+	}
+
+	var ids []ksuid.KSUID
+	for _, arg := range args {
+		id, err := ksuid.Parse(arg)
+		if err != nil {
+			fmt.Printf("Error when parsing %q: %s\n\n", arg, err)
+			flag.PrintDefaults()
+			os.Exit(1)
+		}
+		ids = append(ids, id)
+	}
+
+	for _, id := range ids {
+		if verbose {
+			fmt.Printf("%s: ", id)
+		}
+		print(id)
+	}
+}
+
+func printInspect(id ksuid.KSUID) {
+	const inspectFormat = `
 REPRESENTATION:
 
   String: %v
@@ -30,26 +91,47 @@ COMPONENTS:
     Payload: %v
 
 `
-
-func main() {
-	if len(os.Args) < 2 {
-		fmt.Println(ksuid.New())
-		os.Exit(0)
-	}
-
-	id, err := ksuid.Parse(os.Args[1])
-	if err != nil {
-		fmt.Println("Error when parsing: ", err)
-		fmt.Println()
-		fmt.Println(usage)
-		os.Exit(1)
-	}
-
 	fmt.Printf(inspectFormat,
 		id.String(),
 		strings.ToUpper(hex.EncodeToString(id.Bytes())),
 		id.Time(),
 		id.Timestamp(),
-		strings.ToUpper(hex.EncodeToString(id.Payload())))
+		strings.ToUpper(hex.EncodeToString(id.Payload())),
+	)
+}
 
+func printTime(id ksuid.KSUID) {
+	fmt.Println(id.Time())
+}
+
+func printTimestamp(id ksuid.KSUID) {
+	fmt.Println(id.Timestamp())
+}
+
+func printPayload(id ksuid.KSUID) {
+	os.Stdout.Write(id.Payload())
+}
+
+func printRaw(id ksuid.KSUID) {
+	os.Stdout.Write(id.Bytes())
+}
+
+func printTemplate(id ksuid.KSUID) {
+	b := &bytes.Buffer{}
+	t := template.Must(template.New("").Parse(tpltxt))
+	t.Execute(b, struct {
+		String    string
+		Raw       string
+		Time      time.Time
+		Timestamp uint32
+		Payload   string
+	}{
+		String:    id.String(),
+		Raw:       strings.ToUpper(hex.EncodeToString(id.Bytes())),
+		Time:      id.Time(),
+		Timestamp: id.Timestamp(),
+		Payload:   strings.ToUpper(hex.EncodeToString(id.Payload())),
+	})
+	b.WriteByte('\n')
+	io.Copy(os.Stdout, b)
 }

--- a/ksuid.go
+++ b/ksuid.go
@@ -3,6 +3,7 @@ package ksuid
 import (
 	"bytes"
 	"crypto/rand"
+	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -126,6 +127,42 @@ func (i *KSUID) UnmarshalBinary(b []byte) error {
 	}
 	*i = id
 	return nil
+}
+
+// Value converts the KSUID into a SQL driver value which can be used to
+// directly use the KSUID as parameter to a SQL query.
+func (i KSUID) Value() (driver.Value, error) {
+	return i.String(), nil
+}
+
+// Scan implements the sql.Scanner interface. It supports converting from
+// string, []byte, or nil into a KSUID value. Attempting to convert from
+// another type will return an error.
+func (i *KSUID) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case nil:
+		return i.scan(nil)
+	case []byte:
+		return i.scan(v)
+	case string:
+		return i.scan([]byte(v))
+	default:
+		return fmt.Errorf("Scan: unable to scan type %T into KSUID", v)
+	}
+}
+
+func (i *KSUID) scan(b []byte) error {
+	switch len(b) {
+	case 0:
+		*i = Nil
+		return nil
+	case byteLength:
+		return i.UnmarshalBinary(b)
+	case stringEncodedLength:
+		return i.UnmarshalText(b)
+	default:
+		return errSize
+	}
 }
 
 // Decodes a string-encoded representation of a KSUID object

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -171,5 +172,47 @@ func TestFlag(t *testing.T) {
 
 	if id1 != id2 {
 		t.Error(id1, "!=", id2)
+	}
+}
+
+func TestSqlValuer(t *testing.T) {
+	id, _ := Parse(maxStringEncoded)
+
+	if v, err := id.Value(); err != nil {
+		t.Error(err)
+	} else if s, ok := v.(string); !ok {
+		t.Error("not a string value")
+	} else if s != maxStringEncoded {
+		t.Error("bad string value::", s)
+	}
+}
+
+func TestSqlScanner(t *testing.T) {
+	id1 := New()
+	id2 := New()
+
+	tests := []struct {
+		ksuid KSUID
+		value interface{}
+	}{
+		{Nil, nil},
+		{id1, id1.String()},
+		{id2, id2.Bytes()},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T", test.value), func(t *testing.T) {
+			var id KSUID
+
+			if err := id.Scan(test.value); err != nil {
+				t.Error(err)
+			}
+
+			if id != test.ksuid {
+				t.Error("bad KSUID:")
+				t.Logf("expected %v", test.ksuid)
+				t.Logf("found    %v", id)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This allows us to marshal and unmarshal KSUIDs into textual and binary formats.