### PR TITLE
implement flag interfaces

### DIFF
--- a/ksuid.go
+++ b/ksuid.go
@@ -90,6 +90,18 @@ func (i KSUID) IsNil() bool {
 	return i == Nil
 }
 
+// Get satisfies the flag.Getter interface, making it possible to use KSUIDs as
+// part of of the command line options of a program.
+func (i KSUID) Get() interface{} {
+	return i
+}
+
+// Set satisfies the flag.Value interface, making it possible to use KSUIDs as
+// part of of the command line options of a program.
+func (i *KSUID) Set(s string) error {
+	return i.UnmarshalText([]byte(s))
+}
+
 func (i KSUID) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
 }

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -3,6 +3,7 @@ package ksuid
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"strings"
 	"testing"
 	"time"
@@ -153,6 +154,22 @@ func TestMashalJSON(t *testing.T) {
 	} else if err := json.Unmarshal(b, &id2); err != nil {
 		t.Fatal(err)
 	} else if id1 != id2 {
+		t.Error(id1, "!=", id2)
+	}
+}
+
+func TestFlag(t *testing.T) {
+	var id1 = New()
+	var id2 KSUID
+
+	fset := flag.NewFlagSet("test", flag.ContinueOnError)
+	fset.Var(&id2, "id", "the KSUID")
+
+	if err := fset.Parse([]string{"-id", id1.String()}); err != nil {
+		t.Fatal(err)
+	}
+
+	if id1 != id2 {
 		t.Error(id1, "!=", id2)
 	}
 }


### PR DESCRIPTION
Often forgotten but really useful, implementing the `flag.Value` and `flag.Getter` interfaces makes it possible to load command line arguments directly into a KSUID.