### PR TITLE
optimizations

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -24,7 +24,8 @@ func appendBase2Base(dst []byte, src []byte, inBase int, outBase int) []byte {
 			}
 		}
 
-		// this is really a prepend or remainder to result
+		// Appends in reverse order, the byte slice gets reversed before it's
+		// returned by the function.
 		dst = append(dst, byte(remainder))
 		bs = quotient
 	}

--- a/base62_test.go
+++ b/base62_test.go
@@ -45,7 +45,7 @@ func TestEncodeAndDecodeBase62(t *testing.T) {
 func TestLexographicOrdering(t *testing.T) {
 	unsortedStrings := make([]string, 256)
 	for i := 0; i < 256; i++ {
-		s := encodeBase62([]byte{0, byte(i)})
+		s := string(encodeBase62([]byte{0, byte(i)}))
 		unsortedStrings[i] = strings.Repeat("0", 2-len(s)) + s
 	}
 

--- a/ksuid.go
+++ b/ksuid.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 )
 
@@ -45,9 +44,6 @@ var (
 	errStrSize     = fmt.Errorf("Valid encoded KSUIDs are %v characters", stringEncodedLength)
 	errPayloadSize = fmt.Errorf("Valid KSUID payloads are %v bytes", payloadLengthInBytes)
 
-	paddingZeroesStr   = strings.Repeat("0", stringEncodedLength)
-	paddingZeroesBytes = make([]byte, byteLength)
-
 	// Represents a completely empty (invalid) KSUID
 	Nil KSUID
 )
@@ -68,9 +64,14 @@ func (i KSUID) Append(b []byte) []byte {
 	b = appendEncodeBase62(b, i[:])
 
 	if pad := stringEncodedLength - (len(b) - off); pad > 0 {
-		b = append(b, paddingZeroesStr[:pad]...)
+		zeroes := [...]byte{
+			'0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+			'0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+			'0', '0', '0', '0', '0', '0', '0',
+		}
+		b = append(b, zeroes[:pad]...)
 		copy(b[pad:], b)
-		copy(b, paddingZeroesStr[:pad])
+		copy(b, zeroes[:pad])
 	}
 
 	return b
@@ -195,8 +196,9 @@ func Parse(s string) (KSUID, error) {
 	decoded := appendDecodeBase62(dst[:0], src[:])
 
 	if pad := byteLength - len(decoded); pad > 0 {
+		zeroes := [byteLength]byte{}
 		copy(dst[pad:], dst[:])
-		copy(dst[:], paddingZeroesBytes[:pad])
+		copy(dst[:], zeroes[:pad])
 	}
 
 	return FromBytes(dst[:])

--- a/ksuid.go
+++ b/ksuid.go
@@ -54,7 +54,7 @@ var (
 
 // Append appends the string representation of i to b, returning a slice to a
 // potentially larger memory area.
-func Append(b []byte, i KSUID) []byte {
+func (i KSUID) Append(b []byte) []byte {
 	// This is an optimization that ensures we do at most one memory allocation
 	// when the byte slice capacity is lower than the length of the string
 	// representation of the KSUID.
@@ -94,7 +94,7 @@ func (i KSUID) Payload() []byte {
 
 // String-encoded representation that can be passed through Parse()
 func (i KSUID) String() string {
-	return string(Append(make([]byte, 0, stringEncodedLength), i))
+	return string(i.Append(make([]byte, 0, stringEncodedLength)))
 }
 
 // Raw byte representation of KSUID

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -222,7 +222,7 @@ func BenchmarkAppend(b *testing.B) {
 	k := New()
 
 	for i := 0; i != b.N; i++ {
-		Append(a, k)
+		k.Append(a)
 	}
 }
 

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -216,3 +216,26 @@ func TestSqlScanner(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkAppend(b *testing.B) {
+	a := make([]byte, 0, stringEncodedLength)
+	k := New()
+
+	for i := 0; i != b.N; i++ {
+		Append(a, k)
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	k := New()
+
+	for i := 0; i != b.N; i++ {
+		k.String()
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	for i := 0; i != b.N; i++ {
+		Parse(maxStringEncoded)
+	}
+}

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -239,3 +239,9 @@ func BenchmarkParse(b *testing.B) {
 		Parse(maxStringEncoded)
 	}
 }
+
+func BenchmarkNew(b *testing.B) {
+	for i := 0; i != b.N; i++ {
+		New()
+	}
+}


### PR DESCRIPTION
I noticed that the parsing and formatting operations of KSUIDs were quite inefficient regarding memory allocations, so I spent a bit of time optimizing them.

The biggest gain came from appending to the output buffer when converting from one base to another (instead of prepending) and reversing it at the end. I also changed some internal APIs to make it possible to pass preallocated buffers, and added the `KSUID.Append([]byte) []byte` function to allow formatting of KSUID with zero dynamic memory allocations.

Here are the numbers before the changes:
```
BenchmarkAppend-4   	  200000	      6539 ns/op	    1272 B/op	      95 allocs/op
PASS
ok  	github.com/segmentio/ksuid	1.385s
```
Then after:
```
BenchmarkAppend-4   	  300000	      4297 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/segmentio/ksuid	1.339s
```
And the comparison:
```
benchmark             old ns/op     new ns/op     delta
BenchmarkAppend-4     6539          4297          -34.29%

benchmark             old allocs     new allocs     delta
BenchmarkAppend-4     95             0              -100.00%

benchmark             old bytes     new bytes     delta
BenchmarkAppend-4     1272          0             -100.00%
```

Please take a look and let me know if anything should be changed.