### PR TITLE
Optimize new

### DIFF
--- a/ksuid.go
+++ b/ksuid.go
@@ -279,10 +279,6 @@ func FromBytes(b []byte) (KSUID, error) {
 // should probably only be set once globally. While this is technically
 // thread-safe as in it won't cause corruption, there's no guarantee
 // on ordering.
-//
-// Passing nil to the function tells the package to use the default source
-// of random bytes, which is a deterministic random bits generator seeded
-// from a crypto-random source.
 func SetRand(r io.Reader) {
 	if r == nil {
 		rander = rand.Reader

--- a/ksuid.go
+++ b/ksuid.go
@@ -230,7 +230,7 @@ func New() KSUID {
 // Generates a new KSUID
 func NewRandom() (ksuid KSUID, err error) {
 	// Go's default random number generators are not safe for concurrent use by
-	// multiple goroutines so use of the rander and randBuffer are explicitly
+	// multiple goroutines, the use of the rander and randBuffer are explicitly
 	// synchronized here.
 	randMutex.Lock()
 

--- a/ksuid.go
+++ b/ksuid.go
@@ -229,7 +229,7 @@ func New() KSUID {
 
 // Generates a new KSUID
 func NewRandom() (ksuid KSUID, err error) {
-	// Go's default random number generators are not safe for concurrent used by
+	// Go's default random number generators are not safe for concurrent use by
 	// multiple goroutines so use of the rander and randBuffer are explicitly
 	// synchronized here.
 	randMutex.Lock()

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -253,7 +253,16 @@ func BenchmarkParse(b *testing.B) {
 }
 
 func BenchmarkNew(b *testing.B) {
-	for i := 0; i != b.N; i++ {
-		New()
-	}
+	b.Run("with crypto rand", func(b *testing.B) {
+		SetRand(nil)
+		for i := 0; i != b.N; i++ {
+			New()
+		}
+	})
+	b.Run("with math rand", func(b *testing.B) {
+		SetRand(FastRander)
+		for i := 0; i != b.N; i++ {
+			New()
+		}
+	})
 }

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,55 @@
+package ksuid
+
+import (
+	cryptoRand "crypto/rand"
+	"encoding/binary"
+	"io"
+	"math/rand"
+)
+
+// FastRander is an io.Reader that uses math/rand and is optimized for
+// generating 16 bytes KSUID payloads. It is intended to be used as a
+// performance improvements for programs that have no need for
+// cryptographically secure KSUIDs and is generating a lot of them.
+var FastRander = newRBG()
+
+func newRBG() io.Reader {
+	r, err := newRandomBitsGenerator()
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func newRandomBitsGenerator() (r io.Reader, err error) {
+	var seed int64
+
+	if seed, err = readCryptoRandomSeed(); err != nil {
+		return
+	}
+
+	r = &randSourceReader{source: rand.NewSource(seed).(rand.Source64)}
+	return
+}
+
+func readCryptoRandomSeed() (seed int64, err error) {
+	var b [8]byte
+
+	if _, err = io.ReadFull(cryptoRand.Reader, b[:]); err != nil {
+		return
+	}
+
+	seed = int64(binary.LittleEndian.Uint64(b[:]))
+	return
+}
+
+type randSourceReader struct {
+	source rand.Source64
+}
+
+func (r *randSourceReader) Read(b []byte) (int, error) {
+	// optimized for generating 16 bytes payloads
+	binary.LittleEndian.PutUint64(b[:8], r.source.Uint64())
+	binary.LittleEndian.PutUint64(b[8:], r.source.Uint64())
+	return 16, nil
+}

--- a/rand.go
+++ b/rand.go
@@ -10,7 +10,7 @@ import (
 // FastRander is an io.Reader that uses math/rand and is optimized for
 // generating 16 bytes KSUID payloads. It is intended to be used as a
 // performance improvements for programs that have no need for
-// cryptographically secure KSUIDs and is generating a lot of them.
+// cryptographically secure KSUIDs and are generating a lot of them.
 var FastRander = newRBG()
 
 func newRBG() io.Reader {


### PR DESCRIPTION
The changes in the PR optimize the implementation of `NewRandom`, here's a highlight of the changes:
- Use a non-cryptographic random source to avoid having to make a syscall to generate KSUIDs, use Go's math/rand.Rand seeded with a crypto-random source
- Get rid of of the payload memory pool, use a global buffer instead. Since we have to pay the cost of using a mutex to access the random generator, we load the random bytes in a global buffer synchronized on the same mutex and then copy the results to a local variable.
- Load the payload directly into the generated KSUID variable and inline the time serialization from `FromParts`.
- Change `ReadFull` to `ReadAtLeast`, for some reason the compiled failed to inline this function call and resulted in ~3% of the remaining cost of `NewRandom`.

Here are the numbers before and after:
```
$ go test -run _ -v -bench New -cpuprofile /tmp/cpu -benchmem -memprofile /tmp/mem
BenchmarkNew-4   	 1000000	      1234 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/segmentio/ksuid	1.258s
```
```
$ go test -run _ -v -bench New -cpuprofile /tmp/cpu -benchmem -memprofile /tmp/mem
BenchmarkNew-4   	20000000	       105 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/segmentio/ksuid	2.228s
```

Please take a look and let me know if something should be changed.