### PR TITLE
Add ksuid.Max

### DIFF
--- a/ksuid.go
+++ b/ksuid.go
@@ -49,6 +49,8 @@ var (
 
 	// Represents a completely empty (invalid) KSUID
 	Nil KSUID
+	// Represents the highest value a KSUID can have
+	Max = KSUID{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 )
 
 // Append appends the string representation of i to b, returning a slice to a


### PR DESCRIPTION
@achille-roussel @rbranson 

This adds an exported `Max` that represents the highest value a KSUID can hold.
This is useful as a starting point for scanning through a range of KSUIDs backwards.