### PR TITLE
Allow the format flag on ksuid generated on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,40 @@ $ ./ksuid -f template -t '{{ .Time }}: {{ .Payload }}' $(./ksuid -n 4)
 2017-10-09 21:05:37 -0700 PDT: DF0761769909ABB0C7BB9D66F79FC041
 2017-10-09 21:05:37 -0700 PDT: 1A8F0E3D0BDEB84A5FAD702876F46543
 ```
+
+### Generate detailed versions of new KSUID
+
+Generate a new KSUID with the corresponding time using the time formatting:
+
+```sh
+$ go run cmd/ksuid/main.go -f time -v
+0uk0ava2lavfJwMceJOOEFXEDxl: 2017-10-09 21:56:00 -0700 PDT
+```
+
+Generate 4 new KSUID with details using template formatting:
+
+```sh
+$ ./ksuid -f template -t '{ "timestamp": "{{ .Timestamp }}", "payload": "{{ .Payload }}", "ksuid": "{{.String}}"}' -n 4
+{ "timestamp": "107611700", "payload": "9850EEEC191BF4FF26F99315CE43B0C8", "ksuid": "0uk1Hbc9dQ9pxyTqJ93IUrfhdGq"}
+{ "timestamp": "107611700", "payload": "CC55072555316F45B8CA2D2979D3ED0A", "ksuid": "0uk1HdCJ6hUZKDgcxhpJwUl5ZEI"}
+{ "timestamp": "107611700", "payload": "BA1C205D6177F0992D15EE606AE32238", "ksuid": "0uk1HcdvF0p8C20KtTfdRSB9XIm"}
+{ "timestamp": "107611700", "payload": "67517BA309EA62AE7991B27BB6F2FCAC", "ksuid": "0uk1Ha7hGJ1Q9Xbnkt0yZgNwg3g"}
+```
+
+Display the detailed version of a new KSUID:
+
+```sh
+$ ./ksuid -f inspect
+
+REPRESENTATION:
+
+  String: 0ujzPyRiIAffKhBux4PvQdDqMHY
+     Raw: 066A029C73FC1AA3B2446246D6E89FCD909E8FE8
+
+COMPONENTS:
+
+       Time: 2017-10-09 21:46:20 -0700 PDT
+  Timestamp: 107610780
+    Payload: 73FC1AA3B2446246D6E89FCD909E8FE8
+
+```

--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -23,7 +23,7 @@ var (
 
 func init() {
 	flag.IntVar(&count, "n", 1, "Number of KSUIDs to generate when called with no other arguments.")
-	flag.StringVar(&format, "f", "inspect", "One of inspect, time, timestamp, payload, raw, or template.")
+	flag.StringVar(&format, "f", "string", "One of string, inspect, time, timestamp, payload, raw, or template.")
 	flag.StringVar(&tpltxt, "t", "", "The Go template used to format the output.")
 	flag.BoolVar(&verbose, "v", false, "Turn on verbose mode.")
 }
@@ -34,6 +34,8 @@ func main() {
 
 	var print func(ksuid.KSUID)
 	switch format {
+	case "string":
+		print = printString
 	case "inspect":
 		print = printInspect
 	case "time":
@@ -53,9 +55,8 @@ func main() {
 
 	if len(args) == 0 {
 		for i := 0; i < count; i++ {
-			fmt.Println(ksuid.New())
+			args = append(args, ksuid.New().String())
 		}
-		os.Exit(0)
 	}
 
 	var ids []ksuid.KSUID
@@ -75,6 +76,10 @@ func main() {
 		}
 		print(id)
 	}
+}
+
+func printString(id ksuid.KSUID) {
+	fmt.Println(id.String())
 }
 
 func printInspect(id ksuid.KSUID) {


### PR DESCRIPTION
Currently it's a bit not intuitive to have to be able to format only while giving a KSUID as input especially when there's no warning of any sort when running the comand with format without args. Make it looks like the format is not working.
This PR allows you to use the formatting while generating new KSUID(s).
Examples given in the README.md