### PR TITLE
Fix CompressedSetIter when set ends in a sequence

### DIFF
--- a/set.go
+++ b/set.go
@@ -270,16 +270,16 @@ type CompressedSetIter struct {
 // Next moves the iterator forward, returning true if there a KSUID was found,
 // or false if the iterator as reached the end of the set it was created from.
 func (it *CompressedSetIter) Next() bool {
-	if it.offset == len(it.content) {
-		return false
-	}
-
 	if it.seqlength != 0 {
 		value := incr128(it.lastValue)
 		it.KSUID = value.ksuid(it.timestamp)
 		it.seqlength--
 		it.lastValue = value
 		return true
+	}
+
+	if it.offset == len(it.content) {
+		return false
 	}
 
 	b := it.content[it.offset]

--- a/set_test.go
+++ b/set_test.go
@@ -46,6 +46,10 @@ func TestCompressedSet(t *testing.T) {
 			scenario: "building a compressed set with a single id repeated multiple times produces the id only once",
 			function: testCompressedSetSingle,
 		},
+		{
+			scenario: "iterating over a compressed sequence returns the full sequence",
+			function: testCompressedSetSequence,
+		},
 	}
 
 	for _, test := range tests {
@@ -230,6 +234,30 @@ func testCompressedSetSingle(t *testing.T) {
 
 	if n == 0 {
 		t.Error("no ids were produced by the compressed set")
+	}
+}
+
+func testCompressedSetSequence(t *testing.T) {
+	seq := Sequence{Seed: New()}
+
+	ids := make([]KSUID, 5)
+
+	for i := 0; i < 5; i++ {
+		ids[i], _ = seq.Next()
+	}
+
+	iter := Compress(ids...).Iter()
+
+	index := 0
+	for iter.Next() {
+		if iter.KSUID != ids[index] {
+			t.Errorf("mismatched id at index %d: %s != %s", index, iter.KSUID, ids[index])
+		}
+		index++
+	}
+
+	if index != 5 {
+		t.Errorf("Expected 5 ids, got %d", index)
 	}
 }
 


### PR DESCRIPTION
When the CompressedSet ends in a sequence, only the first ID is produced, as on further calls, it sees that it is at the end of the set and returns `false` before checking if it is in the middle of a sequence.

This swaps the order of those two checks to ensure sequences are completed before the iterator finishes.