### PR TITLE
Fix issue 25

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -1,11 +1,17 @@
 package ksuid
 
+import "errors"
+
 const (
 	// lexographic ordering (based on Unicode table) is 0-9A-Za-z
 	base62Characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	zeroString       = "000000000000000000000000000"
 	offsetUppercase  = 10
 	offsetLowercase  = 36
+)
+
+var (
+	errShortBuffer = errors.New("the output buffer is too small to hold to decoded value")
 )
 
 // Converts a base 62 byte into the number value that it represents.
@@ -102,7 +108,7 @@ func fastAppendEncodeBase62(dst []byte, src []byte) []byte {
 // is 27 bytes long and dst is 20 bytes long.
 //
 // Any unused bytes in dst will be set to zero.
-func fastDecodeBase62(dst []byte, src []byte) {
+func fastDecodeBase62(dst []byte, src []byte) error {
 	const srcBase = 62
 	const dstBase = 4294967296
 
@@ -156,6 +162,10 @@ func fastDecodeBase62(dst []byte, src []byte) {
 			}
 		}
 
+		if n < 4 {
+			return errShortBuffer
+		}
+
 		dst[n-4] = byte(remainder >> 24)
 		dst[n-3] = byte(remainder >> 16)
 		dst[n-2] = byte(remainder >> 8)
@@ -166,6 +176,7 @@ func fastDecodeBase62(dst []byte, src []byte) {
 
 	var zero [20]byte
 	copy(dst[:n], zero[:])
+	return nil
 }
 
 // This function appends the base 62 decoded version of src into dst.

--- a/ksuid.go
+++ b/ksuid.go
@@ -191,10 +191,6 @@ func Parse(s string) (KSUID, error) {
 	return FromBytes(dst[:])
 }
 
-func copyString(s string) string {
-	return string([]byte(s))
-}
-
 func timeToCorrectedUTCTimestamp(t time.Time) uint32 {
 	return uint32(t.Unix() - epochStamp)
 }

--- a/ksuid.go
+++ b/ksuid.go
@@ -30,6 +30,9 @@ const (
 	// The length of a KSUID when string (base62) encoded
 	stringEncodedLength = 27
 
+	// A string-encoded minimum value for a KSUID
+	minStringEncoded = "000000000000000000000000000"
+
 	// A string-encoded maximum value for a KSUID
 	maxStringEncoded = "aWgEPTl1tmebfsQzFP4bxwgy80V"
 )
@@ -46,6 +49,7 @@ var (
 
 	errSize        = fmt.Errorf("Valid KSUIDs are %v bytes", byteLength)
 	errStrSize     = fmt.Errorf("Valid encoded KSUIDs are %v characters", stringEncodedLength)
+	errStrValue    = fmt.Errorf("Valid encoded KSUIDs are bounded by %s and %s", minStringEncoded, maxStringEncoded)
 	errPayloadSize = fmt.Errorf("Valid KSUID payloads are %v bytes", payloadLengthInBytes)
 
 	// Represents a completely empty (invalid) KSUID
@@ -179,8 +183,16 @@ func Parse(s string) (KSUID, error) {
 	dst := [byteLength]byte{}
 
 	copy(src[:], s[:])
-	fastDecodeBase62(dst[:], src[:])
+
+	if err := fastDecodeBase62(dst[:], src[:]); err != nil {
+		return Nil, errStrValue
+	}
+
 	return FromBytes(dst[:])
+}
+
+func copyString(s string) string {
+	return string([]byte(s))
 }
 
 func timeToCorrectedUTCTimestamp(t time.Time) uint32 {

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -99,9 +99,14 @@ func TestParse(t *testing.T) {
 
 func TestIssue25(t *testing.T) {
 	// https://github.com/segmentio/ksuid/issues/25
-	_, err := Parse("aaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	if err != errStrValue {
-		t.Error("invalid KSUID representations cannot be successfully parsed, got err =", err)
+	for _, s := range []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"aWgEPTl1tmebfsQzFP4bxwgy80!",
+	} {
+		_, err := Parse(s)
+		if err != errStrValue {
+			t.Error("invalid KSUID representations cannot be successfully parsed, got err =", err)
+		}
 	}
 }
 

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -97,6 +97,14 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestIssue25(t *testing.T) {
+	// https://github.com/segmentio/ksuid/issues/25
+	_, err := Parse("aaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != errStrValue {
+		t.Error("invalid KSUID representations cannot be successfully parsed, got err =", err)
+	}
+}
+
 func TestEncodeAndDecode(t *testing.T) {
 	x := New()
 	builtFromEncodedString, err := Parse(x.String())


### PR DESCRIPTION
Fixes #25 

This PR changes the fastDecodeBase62 implementation to prevent out-of-bounds errors when invalid KSUIDs are decoded.