### PR TITLE
Bound Check Elimination: BenchmarkAppendFastDecodeBase62 faster by 8%

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -112,6 +112,10 @@ func fastDecodeBase62(dst []byte, src []byte) error {
 	const srcBase = 62
 	const dstBase = 4294967296
 
+	// This line helps BCE (Bounds Check Elimination).
+	// It may be safely removed.
+	_ = src[26]
+
 	parts := [27]byte{
 		base62Value(src[0]),
 		base62Value(src[1]),


### PR DESCRIPTION
```
benchmark                              old ns/op     new ns/op     delta
BenchmarkAppendFastDecodeBase62-12     143           131           -8.39%
```