### PR TITLE
Use text/template for ksuid cmd

### DIFF
--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -5,10 +5,10 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/segmentio/ksuid"


### PR DESCRIPTION
html/template includes escaping which is inappropriate for this use.

Fixes #37