### PR TITLE
tweaked scan method to work with most sql drivers // Added Must 

### DIFF
--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -309,7 +309,7 @@ func TestGetTimestamp(t *testing.T) {
 	x, _ := NewRandomWithTime(nowTime)
 	xTime := int64(x.Timestamp())
 	unix := nowTime.Unix()
-	if xTime != unix - epochStamp {
+	if xTime != unix-epochStamp {
 		t.Fatal(xTime, "!=", unix)
 	}
 }

--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,56 @@
+package ksuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the sql.Scanner interface. It supports converting from
+// string, []byte, or nil into a KSUID value. Attempting to convert from
+// another type will return an error.
+func (i *KSUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case nil:
+		return nil
+	case string:
+		// if an empty KSUID comes from a table, we return a null KSUID
+		if src == "" {
+			return nil
+		}
+		k, err := Parse(src)
+		if err != nil {
+			return fmt.Errorf("Scan: %v", err)
+		}
+		*i = k
+	case []byte:
+		// if an empty KSUID comes from a table, we return a null KSUID
+		if len(src) == 0 {
+			return nil
+		}
+		// assumes a simple slice of bytes if [byteLength] bytes
+		if len(src) == byteLength {
+			copy((*i)[:], src)
+			return nil
+		}
+
+		if len(src) == stringEncodedLength {
+			return i.Scan(string(src))
+		}
+
+		return i.Scan(string(src))
+
+	default:
+		return fmt.Errorf("Scan: unable to scan type %T into KSUID", src)
+	}
+	return nil
+}
+
+// Value implements sql.Valuer so that KSUIDs can be written to databases
+// transparently. Currently, KSUIDs map to strings. Please consult database-specific
+// driver documentation for matching types.
+func (i *KSUID) Value() (driver.Value, error) {
+	if i == nil || i.IsNil() {
+		return nil, nil
+	}
+	return i.String(), nil
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,113 @@
+package ksuid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScan(t *testing.T) {
+	stringTest := "1al9byIH8Ze6OLkD5tZqmByJkSX"
+	badTypeTest := 6
+	invalidTest := "1al9byIH8Ze6OLkD5tZqmByJk"
+
+	byteTest := make([]byte, byteLength)
+	byteTestKSUID := Must(Parse(stringTest))
+	copy(byteTest, byteTestKSUID[:])
+	textTest := []byte(stringTest)
+
+	// valid tests
+
+	var ksuid KSUID
+	err := (&ksuid).Scan(stringTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&ksuid).Scan([]byte(stringTest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = (&ksuid).Scan(byteTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&ksuid).Scan(textTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bad type tests
+
+	err = (&ksuid).Scan(badTypeTest)
+	if err == nil {
+		t.Error("int correctly parsed and shouldn't have")
+	}
+	if !strings.Contains(err.Error(), "unable to scan type") {
+		t.Error("attempting to parse an int returned an incorrect error message")
+	}
+
+	// invalid/incomplete ksuids
+	err = (&ksuid).Scan(invalidTest)
+	if err == nil {
+		t.Error("invalid uuid was parsed without error")
+	}
+	if !strings.Contains(err.Error(), "Valid encoded KSUIDs") {
+		t.Error("attempting to parse an invalid KSUID returned an incorrect error message")
+	}
+
+	err = (&ksuid).Scan(byteTest[:len(byteTest)-2])
+	if err == nil {
+		t.Error("invalid byte ksuid was parsed without error")
+	}
+	if !strings.Contains(err.Error(), "Valid encoded KSUIDs") {
+		t.Error("attempting to parse an invalid byte KSUID returned an incorrect error message")
+	}
+
+	// empty tests
+
+	ksuid = KSUID{}
+	var emptySlice []byte
+	err = (&ksuid).Scan(emptySlice)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, v := range ksuid {
+		if v != 0 {
+			t.Error("KSUID was not nil after scanning empty byte slice")
+		}
+	}
+
+	ksuid = KSUID{}
+	var emptyString string
+	err = (&ksuid).Scan(emptyString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range ksuid {
+		if v != 0 {
+			t.Error("KSUID was not nil after scanning empty string")
+		}
+	}
+
+	ksuid = KSUID{}
+	err = (&ksuid).Scan(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range ksuid {
+		if v != 0 {
+			t.Error("KSUID was not nil after scanning nil")
+		}
+	}
+}
+
+func TestValue(t *testing.T) {
+	stringTest := "1al9byIH8Ze6OLkD5tZqmByJkSX"
+	ksuid := Must(Parse(stringTest))
+	val, _ := ksuid.Value()
+	if val != stringTest {
+		t.Error("Value() did ot return expected string")
+	}
+}


### PR DESCRIPTION
Stripped the Scan method a 'lil bit. As i had problems to Scan with sqlx library. All tests pass.

```
=== RUN   TestScan
--- PASS: TestScan (0.00s)
=== RUN   TestValue
--- PASS: TestValue (0.00s)
```

`UnmarshalText()`, `UnmarshalBinary()`are no longer required for Scan.

`TestSqlScanner()` from `ksuid_test.go` is still implemented and PASS

```
--- PASS: TestSqlScanner (0.00s)
    --- PASS: TestSqlScanner/<nil> (0.00s)
    --- PASS: TestSqlScanner/string (0.00s)
    --- PASS: TestSqlScanner/[]uint8 (0.00s)
``` 

Same for `TestSqlValuer()` `--- PASS: TestSqlValuer (0.00s)`