### PR TITLE
Optimize byte swap base62 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ $ ksuid -f template -t '{ "timestamp": "{{ .Timestamp }}", "payload": "{{ .Paylo
 { "timestamp": "107611700", "payload": "67517BA309EA62AE7991B27BB6F2FCAC", "ksuid": "0uk1Ha7hGJ1Q9Xbnkt0yZgNwg3g"}
 ```
 
+## Implementations for other languages
+
+- Python: [svix-ksuid](https://github.com/svixhq/python-ksuid/)
+- Ruby: [ksuid-ruby](https://github.com/michaelherold/ksuid-ruby)
+- Java: [ksuid](https://github.com/ksuid/ksuid)
+- Rust: [rksuid](https://github.com/nharring/rksuid)
+- dotNet: [Ksuid.Net](https://github.com/JoyMoe/Ksuid.Net)
+
 ## License
 
 ksuid source code is available under an MIT [License](/LICENSE.md).

--- a/base62.go
+++ b/base62.go
@@ -1,6 +1,9 @@
 package ksuid
 
-import "errors"
+import (
+	"encoding/binary"
+	"errors"
+)
 
 const (
 	// lexographic ordering (based on Unicode table) is 0-9A-Za-z
@@ -41,23 +44,11 @@ func fastEncodeBase62(dst []byte, src []byte) {
 	// from because this is a O(N^2) algorithm, and we make N = N / 4 by working
 	// on 32 bits at a time.
 	parts := [5]uint32{
-		/*
-			These is an inlined version of:
-
-			  binary.BigEndian.Uint32(src[0:4]),
-			  binary.BigEndian.Uint32(src[4:8]),
-			  binary.BigEndian.Uint32(src[8:12]),
-			  binary.BigEndian.Uint32(src[12:16]),
-			  binary.BigEndian.Uint32(src[16:20]),
-
-			For some reason it gave better performance, may be caused by the
-			bound check that the Uint32 function does.
-		*/
-		uint32(src[0])<<24 | uint32(src[1])<<16 | uint32(src[2])<<8 | uint32(src[3]),
-		uint32(src[4])<<24 | uint32(src[5])<<16 | uint32(src[6])<<8 | uint32(src[7]),
-		uint32(src[8])<<24 | uint32(src[9])<<16 | uint32(src[10])<<8 | uint32(src[11]),
-		uint32(src[12])<<24 | uint32(src[13])<<16 | uint32(src[14])<<8 | uint32(src[15]),
-		uint32(src[16])<<24 | uint32(src[17])<<16 | uint32(src[18])<<8 | uint32(src[19]),
+		binary.BigEndian.Uint32(src[0:4]),
+		binary.BigEndian.Uint32(src[4:8]),
+		binary.BigEndian.Uint32(src[8:12]),
+		binary.BigEndian.Uint32(src[12:16]),
+		binary.BigEndian.Uint32(src[16:20]),
 	}
 
 	n := len(dst)


### PR DESCRIPTION
This PR revisits an optimization that was added when we originally released this package, but appears not to be needed anymore:
```
name                    old time/op  new time/op  delta
AppendFastEncodeBase62   174ns ± 3%   165ns ± 3%  -4.91%  (p=0.000 n=10+10)
```