### PR TITLE
add alternative link to Java implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ $ ksuid -f template -t '{ "timestamp": "{{ .Timestamp }}", "payload": "{{ .Paylo
 - Python: [svix-ksuid](https://github.com/svixhq/python-ksuid/)
 - Ruby: [ksuid-ruby](https://github.com/michaelherold/ksuid-ruby)
 - Java: [ksuid](https://github.com/ksuid/ksuid)
+- Java: [ksuid-creator](https://github.com/f4b6a3/ksuid-creator)
 - Rust: [rksuid](https://github.com/nharring/rksuid)
 - dotNet: [Ksuid.Net](https://github.com/JoyMoe/Ksuid.Net)
 


### PR DESCRIPTION
Add link to another Java implementation in README file: [KSUID Creator](https://github.com/f4b6a3/ksuid-creator).

### How to use

Create a KSUID:

```java
Ksuid ksuid = KsuidCreator.getKsuid();
```

Create a KSUID with subsecond precision:

```java
Ksuid ksuid = KsuidCreator.getKsuidMs();
```

Create a Monotonic KSUID, similar to Segment's [`sequence.go`](https://github.com/segmentio/ksuid/blob/master/sequence.go)):

```java
Ksuid ksuid = KsuidCreator.getMonotonicKsuid();
```

The source code has a good amount of [unit tests](https://github.com/f4b6a3/ksuid-creator/tree/main/src/test/java/com/github/f4b6a3/ksuid). It also has a [micro benchmark](https://github.com/f4b6a3/ksuid-creator/tree/main/benchmark) to check if the performance is good for your needs.
