### PR TITLE
README: replace the Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ $ ksuid -f template -t '{ "timestamp": "{{ .Timestamp }}", "payload": "{{ .Paylo
 
 - Python: [svix-ksuid](https://github.com/svixhq/python-ksuid/)
 - Ruby: [ksuid-ruby](https://github.com/michaelherold/ksuid-ruby)
-- Java: [ksuid](https://github.com/ksuid/ksuid)
-- Rust: [rksuid](https://github.com/nharring/rksuid)
+- Java: [ksuid](https://github.com/svix/rust-ksuid)
+- Rust: [svix-ksuid](https://github.com/svix/rust-ksuid)
 - dotNet: [Ksuid.Net](https://github.com/JoyMoe/Ksuid.Net)
 - Erlang: [erl-ksuid](https://github.com/exograd/erl-ksuid)
 


### PR DESCRIPTION
When I created #49 I used the rust implementation that I thought was best
based on looking at github/crates.io

Though having actually used it now, it's very much lacking, so I ended up
implementing a new one that has a saner internal representation, integrates
with the rest of the Rust ecosystem, and tests a good chunk of the KSUID
value space for correctness, as can be seen in:
https://github.com/svix/rust-ksuid/blob/main/tests/test_kuids.txt