### PR TITLE
Fix date typo in epochStamp comment

### DIFF
--- a/ksuid.go
+++ b/ksuid.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// KSUID's epoch starts more recently so that the 32-bit number space gives a
-	// significantly higher useful lifetime of around 136 years from March 2017.
+	// significantly higher useful lifetime of around 136 years from May 2014.
 	// This number (14e8) was picked to be easy to remember.
 	epochStamp int64 = 1400000000
 


### PR DESCRIPTION
136 years (2^32 seconds) is the time available in a second-precision 32-bit timestamp. If the offset used is 1400000000 (which is 2014-05-13T16:53:20Z) then you would have 136 years available from May 2014 (not March 2017).