### PR TITLE
feat: initial changes for epoch nano support

### DIFF
--- a/cmd/ksuid/main.go
+++ b/cmd/ksuid/main.go
@@ -128,7 +128,7 @@ func printTemplate(id ksuid.KSUID) {
 		String    string
 		Raw       string
 		Time      time.Time
-		Timestamp uint32
+		Timestamp uint64
 		Payload   string
 	}{
 		String:    id.String(),

--- a/ksuid.go
+++ b/ksuid.go
@@ -15,31 +15,37 @@ import (
 const (
 	// KSUID's epoch starts more recently so that the 32-bit number space gives a
 	// significantly higher useful lifetime of around 136 years from March 2017.
-	// This number (14e8) was picked to be easy to remember.
-	epochStamp int64 = 1400000000
+	// This number (14e8 in s) was picked to be easy to remember.
+	epochStamp uint64 = 1400000000000000000
 
 	// Timestamp is a uint32
-	timestampLengthInBytes = 4
+	timestampLengthInBytes = 8
 
 	// Payload is 16-bytes
 	payloadLengthInBytes = 16
 
-	// KSUIDs are 20 bytes when binary encoded
+	// KSUIDs are 24 bytes when binary encoded (8 byte timestamp + 16 byte payload)
 	byteLength = timestampLengthInBytes + payloadLengthInBytes
 
 	// The length of a KSUID when string (base62) encoded
-	stringEncodedLength = 27
+	stringEncodedLength = 32
 
 	// A string-encoded minimum value for a KSUID
-	minStringEncoded = "000000000000000000000000000"
+	minStringEncoded = "00000000000000000000000000000000"
 
 	// A string-encoded maximum value for a KSUID
-	maxStringEncoded = "aWgEPTl1tmebfsQzFP4bxwgy80V"
+	// maxStringEncoded = "aWgEPTl1tmebfsQzFP4bxwgy80V"
+
+	// A 24-byte binary value (all set to 0xFF) needs 32 base62 characters to be fully represented
+	// this when decoded should give me all 0xFF bytes
+	// maxStringEncoded = "aWgEPTl1tmebfsQzFP4bxwgy80V7n9vD"
+	maxStringEncoded = "lFA6LboL2xx0ldQH2K1TdSrwuqMMiME3"
 )
 
-// KSUIDs are 20 bytes:
-//  00-03 byte: uint32 BE UTC timestamp with custom epoch
-//  04-19 byte: random "payload"
+// KSUIDs are 24 bytes:
+//
+//	00-07 byte: uint64 BE UTC timestamp with custom epoch
+//	08-23 byte: random "payload"
 type KSUID [byteLength]byte
 
 var (
@@ -55,7 +61,7 @@ var (
 	// Represents a completely empty (invalid) KSUID
 	Nil KSUID
 	// Represents the highest value a KSUID can have
-	Max = KSUID{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
+	Max = KSUID{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 )
 
 // Append appends the string representation of i to b, returning a slice to a
@@ -71,8 +77,8 @@ func (i KSUID) Time() time.Time {
 
 // The timestamp portion of the ID as a bare integer which is uncorrected
 // for KSUID's special epoch.
-func (i KSUID) Timestamp() uint32 {
-	return binary.BigEndian.Uint32(i[:timestampLengthInBytes])
+func (i KSUID) Timestamp() uint64 {
+	return binary.BigEndian.Uint64(i[:timestampLengthInBytes])
 }
 
 // The 16-byte random payload without the timestamp
@@ -179,13 +185,19 @@ func Parse(s string) (KSUID, error) {
 		return Nil, errStrSize
 	}
 
+	// Verify the string is within bounds
+	if s < minStringEncoded || s > maxStringEncoded {
+		return Nil, errStrValue
+	}
+
 	src := [stringEncodedLength]byte{}
 	dst := [byteLength]byte{}
 
-	copy(src[:], s[:])
+	// Copy the string into our src buffer
+	copy(src[:], s)
 
 	if err := fastDecodeBase62(dst[:], src[:]); err != nil {
-		return Nil, errStrValue
+		return Nil, err
 	}
 
 	return FromBytes(dst[:])
@@ -201,12 +213,12 @@ func ParseOrNil(s string) KSUID {
 	return ksuid
 }
 
-func timeToCorrectedUTCTimestamp(t time.Time) uint32 {
-	return uint32(t.Unix() - epochStamp)
+func timeToCorrectedUTCTimestamp(t time.Time) uint64 {
+	return uint64(t.UnixNano()) - epochStamp
 }
 
-func correctedUTCTimestampToTime(ts uint32) time.Time {
-	return time.Unix(int64(ts)+epochStamp, 0)
+func correctedUTCTimestampToTime(ts uint64) time.Time {
+	return time.Unix(0, int64(ts+epochStamp))
 }
 
 // Generates a new KSUID. In the strange case that random bytes
@@ -228,6 +240,7 @@ func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
 	// Go's default random number generators are not safe for concurrent use by
 	// multiple goroutines, the use of the rander and randBuffer are explicitly
 	// synchronized here.
+	fmt.Println(t.UnixNano())
 	randMutex.Lock()
 
 	_, err = io.ReadAtLeast(rander, randBuffer[:], len(randBuffer))
@@ -241,7 +254,7 @@ func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
 	}
 
 	ts := timeToCorrectedUTCTimestamp(t)
-	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
+	binary.BigEndian.PutUint64(ksuid[:timestampLengthInBytes], ts)
 	return
 }
 
@@ -254,7 +267,7 @@ func FromParts(t time.Time, payload []byte) (KSUID, error) {
 	var ksuid KSUID
 
 	ts := timeToCorrectedUTCTimestamp(t)
-	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
+	binary.BigEndian.PutUint64(ksuid[:timestampLengthInBytes], ts)
 
 	copy(ksuid[timestampLengthInBytes:], payload)
 

--- a/set_test.go
+++ b/set_test.go
@@ -1,6 +1,7 @@
 package ksuid
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -57,27 +58,42 @@ func TestCompressedSet(t *testing.T) {
 	}
 }
 
+// Helper to generate test data
+func generateTestKSUIDs() ([]KSUID, string) {
+	ids := []KSUID{New(), New(), New()}
+	for _, id := range ids {
+		fmt.Println(id.String())
+		fmt.Println(id.Timestamp())
+	}
+	expected := fmt.Sprintf(`["%s", "%s", "%s"]`, ids[0], ids[1], ids[2])
+	return ids, expected
+}
+
 func testCompressedSetString(t *testing.T) {
-	id1, _ := Parse("0uHjRkQoL2JKAQIULPdqqb5fOkk")
-	id2, _ := Parse("0uHjRvkOG5CbtoXW5oCEp3L2xBu")
-	id3, _ := Parse("0uHjSJ4Pe5606kT2XWixK6dirlo")
+	ids, expected := generateTestKSUIDs()
+	set := Compress(ids...)
 
-	set := Compress(id1, id2, id3)
-
-	if s := set.String(); s != `["0uHjRkQoL2JKAQIULPdqqb5fOkk", "0uHjRvkOG5CbtoXW5oCEp3L2xBu", "0uHjSJ4Pe5606kT2XWixK6dirlo"]` {
-		t.Error(s)
+	fmt.Println(set.String())
+	if s := set.String(); s != expected {
+		t.Errorf("got %s, want %s", s, expected)
 	}
 }
 
 func testCompressedSetGoString(t *testing.T) {
-	id1, _ := Parse("0uHjRkQoL2JKAQIULPdqqb5fOkk")
-	id2, _ := Parse("0uHjRvkOG5CbtoXW5oCEp3L2xBu")
-	id3, _ := Parse("0uHjSJ4Pe5606kT2XWixK6dirlo")
+	id1, _ := Parse("00000000000000008iSPAcOFKMKMlaAS")
+	id2, _ := Parse("00000000000000008iSPBmckldOJIs7g")
+	id3, _ := Parse("00000000000000008iSPBmcoY3a17bPN")
 
 	set := Compress(id1, id2, id3)
 
-	if s := set.GoString(); s != `ksuid.CompressedSet{"0uHjRkQoL2JKAQIULPdqqb5fOkk", "0uHjRvkOG5CbtoXW5oCEp3L2xBu", "0uHjSJ4Pe5606kT2XWixK6dirlo"}` {
-		t.Error(s)
+	expected := `ksuid.CompressedSet{` +
+		`"00000000000000008iSPAcOFKMKMlaAS", ` +
+		`"00000000000000008iSPBmckldOJIs7g", ` +
+		`"00000000000000008iSPBmcoY3a17bPN"` +
+		`}`
+
+	if got := set.GoString(); got != expected {
+		t.Errorf("GoString() = %v, want %v", got, expected)
 	}
 }
 

--- a/uint128.go
+++ b/uint128.go
@@ -24,10 +24,10 @@ func makeUint128FromPayload(payload []byte) uint128 {
 	}
 }
 
-func (v uint128) ksuid(timestamp uint32) (out KSUID) {
-	binary.BigEndian.PutUint32(out[:4], timestamp) // time
-	binary.BigEndian.PutUint64(out[4:12], v[1])    // high
-	binary.BigEndian.PutUint64(out[12:], v[0])     // low
+func (v uint128) ksuid(timestamp uint64) (out KSUID) {
+	binary.BigEndian.PutUint64(out[:timestampLengthInBytes], timestamp)                    // timestamp
+	binary.BigEndian.PutUint64(out[timestampLengthInBytes:timestampLengthInBytes+8], v[1]) // high
+	binary.BigEndian.PutUint64(out[timestampLengthInBytes+8:], v[0])                       // low
 	return
 }
 

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -2,6 +2,7 @@ package ksuid
 
 import (
 	"fmt"
+	"math"
 	"testing"
 )
 
@@ -165,5 +166,88 @@ func BenchmarkSub128(b *testing.B) {
 
 	for i := 0; i != b.N; i++ {
 		sub128(x, y)
+	}
+}
+
+func TestUint128WithLargeTimestamp(t *testing.T) {
+	// Test cases with 8-byte timestamps
+	tests := []struct {
+		name      string
+		timestamp uint64
+		payload   uint128
+		expected  KSUID
+	}{
+		{
+			name:      "max_timestamp_zero_payload",
+			timestamp: math.MaxUint64,
+			payload:   makeUint128(0, 0),
+			expected: KSUID{
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // max timestamp
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // payload hi
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // payload lo
+			},
+		},
+		{
+			name:      "zero_timestamp_max_payload",
+			timestamp: 0,
+			payload:   makeUint128(math.MaxUint64, math.MaxUint64),
+			expected: KSUID{
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // zero timestamp
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // payload hi
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // payload lo
+			},
+		},
+		{
+			name:      "large_timestamp_mixed_payload",
+			timestamp: uint64(1 << 63), // Large timestamp
+			payload:   makeUint128(0xAAAAAAAAAAAAAAAA, 0x5555555555555555),
+			expected: KSUID{
+				0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // large timestamp
+				0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, // payload hi
+				0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, // payload lo
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test ksuid method
+			result := tt.payload.ksuid(tt.timestamp)
+			if result != tt.expected {
+				t.Errorf("ksuid() = %v, want %v", result, tt.expected)
+			}
+
+			// Test uint128Payload method
+			extractedPayload := uint128Payload(result)
+			if extractedPayload != tt.payload {
+				t.Errorf("uint128Payload() = %v, want %v", extractedPayload, tt.payload)
+			}
+
+			// Verify timestamp
+			if result.Timestamp() != tt.timestamp {
+				t.Errorf("Timestamp() = %v, want %v", result.Timestamp(), tt.timestamp)
+			}
+		})
+	}
+}
+
+func TestUint128PayloadRoundTrip(t *testing.T) {
+	// Create a KSUID with known values
+	id := KSUID{
+		0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, // timestamp
+		0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, // payload hi
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, // payload lo
+	}
+
+	// Extract payload
+	payload := uint128Payload(id)
+
+	// Convert back to KSUID
+	timestamp := id.Timestamp()
+	newID := payload.ksuid(timestamp)
+
+	// Compare
+	if newID != id {
+		t.Errorf("Round trip failed:\nOriginal: %v\nGot:      %v", id, newID)
 	}
 }


### PR DESCRIPTION
The new one generate 32 bytes ksuid with epoch timestamp in nanosecods.

----

Some test cases with max ksuid for 32 bytes are still failing




--- Wrong repo, my bad