### PR TITLE
fix: reject invalid base62 characters in Parse

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -14,18 +14,22 @@ const (
 )
 
 var (
-	errShortBuffer = errors.New("the output buffer is too small to hold to decoded value")
+	errShortBuffer   = errors.New("the output buffer is too small to hold to decoded value")
+	errInvalidBase62 = errors.New("invalid base62 character in KSUID")
 )
 
 // Converts a base 62 byte into the number value that it represents.
+// Returns 0xFF if digit is not a valid base62 character.
 func base62Value(digit byte) byte {
 	switch {
 	case digit >= '0' && digit <= '9':
 		return digit - '0'
 	case digit >= 'A' && digit <= 'Z':
 		return offsetUppercase + (digit - 'A')
-	default:
+	case digit >= 'a' && digit <= 'z':
 		return offsetLowercase + (digit - 'a')
+	default:
+		return 0xFF
 	}
 }
 
@@ -137,6 +141,11 @@ func fastDecodeBase62(dst []byte, src []byte) error {
 		base62Value(src[24]),
 		base62Value(src[25]),
 		base62Value(src[26]),
+	}
+	for _, c := range parts {
+		if c >= 62 {
+			return errInvalidBase62
+		}
 	}
 
 	n := len(dst)

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -387,3 +387,19 @@ func BenchmarkNew(b *testing.B) {
 		}
 	})
 }
+
+func TestParseInvalidBase62(t *testing.T) {
+	// Issue #74: non-base62 characters must be rejected.
+	if _, err := Parse("0??????????????????????????"); err == nil {
+		t.Fatal("expected error for non-base62 characters")
+	}
+	valid := New().String()
+	b := []byte(valid)
+	b[5] = '!'
+	if _, err := Parse(string(b)); err == nil {
+		t.Fatal("expected error for invalid character in the middle")
+	}
+	if _, err := Parse(valid); err != nil {
+		t.Fatalf("valid KSUID rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`Parse` accepted non-base62 characters (e.g. `?`, `!`) because `base62Value` mapped anything outside `0-9A-Z` into the lowercase range via unchecked arithmetic.

Invalid digits now return an error. Fixes #74.

## Test plan

- [x] `go test -run TestParseInvalidBase62`
- [x] full package tests