### PR TITLE
validate timestamp bounds in NewRandomWithTime and FromParts (fixes #58)

### DIFF
--- a/ksuid.go
+++ b/ksuid.go
@@ -38,8 +38,9 @@ const (
 )
 
 // KSUIDs are 20 bytes:
-//  00-03 byte: uint32 BE UTC timestamp with custom epoch
-//  04-19 byte: random "payload"
+//
+//	00-03 byte: uint32 BE UTC timestamp with custom epoch
+//	04-19 byte: random "payload"
 type KSUID [byteLength]byte
 
 var (
@@ -51,6 +52,7 @@ var (
 	errStrSize     = fmt.Errorf("Valid encoded KSUIDs are %v characters", stringEncodedLength)
 	errStrValue    = fmt.Errorf("Valid encoded KSUIDs are bounded by %s and %s", minStringEncoded, maxStringEncoded)
 	errPayloadSize = fmt.Errorf("Valid KSUID payloads are %v bytes", payloadLengthInBytes)
+	errTime        = fmt.Errorf("Valid KSUID timestamps are bounded by %s and %s", time.Unix(epochStamp, 0).UTC(), time.Unix(epochStamp+math.MaxUint32, 0).UTC())
 
 	// Represents a completely empty (invalid) KSUID
 	Nil KSUID
@@ -201,8 +203,12 @@ func ParseOrNil(s string) KSUID {
 	return ksuid
 }
 
-func timeToCorrectedUTCTimestamp(t time.Time) uint32 {
-	return uint32(t.Unix() - epochStamp)
+func timeToCorrectedUTCTimestamp(t time.Time) (uint32, error) {
+	u := t.Unix()
+	if u < epochStamp || u > epochStamp+math.MaxUint32 {
+		return 0, errTime
+	}
+	return uint32(u - epochStamp), nil
 }
 
 func correctedUTCTimestampToTime(ts uint32) time.Time {
@@ -225,6 +231,11 @@ func NewRandom() (ksuid KSUID, err error) {
 }
 
 func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
+	ts, err := timeToCorrectedUTCTimestamp(t)
+	if err != nil {
+		return Nil, err
+	}
+
 	// Go's default random number generators are not safe for concurrent use by
 	// multiple goroutines, the use of the rander and randBuffer are explicitly
 	// synchronized here.
@@ -240,7 +251,6 @@ func NewRandomWithTime(t time.Time) (ksuid KSUID, err error) {
 		return
 	}
 
-	ts := timeToCorrectedUTCTimestamp(t)
 	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
 	return
 }
@@ -251,9 +261,12 @@ func FromParts(t time.Time, payload []byte) (KSUID, error) {
 		return Nil, errPayloadSize
 	}
 
-	var ksuid KSUID
+	ts, err := timeToCorrectedUTCTimestamp(t)
+	if err != nil {
+		return Nil, err
+	}
 
-	ts := timeToCorrectedUTCTimestamp(t)
+	var ksuid KSUID
 	binary.BigEndian.PutUint32(ksuid[:timestampLengthInBytes], ts)
 
 	copy(ksuid[timestampLengthInBytes:], payload)

--- a/ksuid_test.go
+++ b/ksuid_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"testing"
@@ -309,7 +310,7 @@ func TestGetTimestamp(t *testing.T) {
 	x, _ := NewRandomWithTime(nowTime)
 	xTime := int64(x.Timestamp())
 	unix := nowTime.Unix()
-	if xTime != unix - epochStamp {
+	if xTime != unix-epochStamp {
 		t.Fatal(xTime, "!=", unix)
 	}
 }
@@ -386,4 +387,72 @@ func BenchmarkNew(b *testing.B) {
 			New()
 		}
 	})
+}
+
+func TestFromPartsTimestampBounds(t *testing.T) {
+	payload := make([]byte, payloadLengthInBytes)
+
+	// Valid exact epoch timestamp: May 13, 2014
+	epochTime := time.Unix(epochStamp, 0)
+	id, err := FromParts(epochTime, payload)
+	if err != nil {
+		t.Fatalf("expected epoch time to be valid, got: %v", err)
+	}
+	if id.Timestamp() != 0 {
+		t.Errorf("expected timestamp 0 at epoch, got: %d", id.Timestamp())
+	}
+
+	// Valid exact max timestamp
+	maxTime := time.Unix(epochStamp+math.MaxUint32, 0)
+	id, err = FromParts(maxTime, payload)
+	if err != nil {
+		t.Fatalf("expected max time to be valid, got: %v", err)
+	}
+	if id.Timestamp() != math.MaxUint32 {
+		t.Errorf("expected timestamp %d at maxTime, got: %d", uint32(math.MaxUint32), id.Timestamp())
+	}
+
+	// Invalid: 1 second before epoch
+	preEpoch := time.Unix(epochStamp-1, 0)
+	if _, err := FromParts(preEpoch, payload); err != errTime {
+		t.Errorf("expected errTime for pre-epoch time, got: %v", err)
+	}
+	if id := FromPartsOrNil(preEpoch, payload); id != Nil {
+		t.Errorf("expected Nil for FromPartsOrNil with pre-epoch time, got: %v", id)
+	}
+	if _, err := NewRandomWithTime(preEpoch); err != errTime {
+		t.Errorf("expected errTime for NewRandomWithTime with pre-epoch time, got: %v", err)
+	}
+
+	// Invalid: year 2000 (issue #58 reproduction)
+	y2k := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := FromParts(y2k, payload); err != errTime {
+		t.Errorf("expected errTime for year 2000, got: %v", err)
+	}
+	if id := FromPartsOrNil(y2k, payload); id != Nil {
+		t.Errorf("expected Nil for FromPartsOrNil with year 2000, got: %v", id)
+	}
+
+	// Invalid: zero value time.Time{}
+	var zeroTime time.Time
+	if _, err := FromParts(zeroTime, payload); err != errTime {
+		t.Errorf("expected errTime for zero time, got: %v", err)
+	}
+
+	// Invalid: 1 second after max timestamp
+	postMax := time.Unix(epochStamp+math.MaxUint32+1, 0)
+	if _, err := FromParts(postMax, payload); err != errTime {
+		t.Errorf("expected errTime for post-max time, got: %v", err)
+	}
+	if id := FromPartsOrNil(postMax, payload); id != Nil {
+		t.Errorf("expected Nil for FromPartsOrNil with post-max time, got: %v", id)
+	}
+	if _, err := NewRandomWithTime(postMax); err != errTime {
+		t.Errorf("expected errTime for NewRandomWithTime with post-max time, got: %v", err)
+	}
+
+	// Invalid payload size still takes precedence or returns errPayloadSize
+	if _, err := FromParts(epochTime, make([]byte, 10)); err != errPayloadSize {
+		t.Errorf("expected errPayloadSize, got: %v", err)
+	}
 }


### PR DESCRIPTION
### Summary
Fixes #58

KSUID timestamps are stored as a 32-bit big-endian offset relative to a custom epoch (`1400000000` / May 13, 2014 16:53:20 UTC). Previously, `timeToCorrectedUTCTimestamp(t)` computed `uint32(t.Unix() - epochStamp)` without boundary checks:
- Any timestamp prior to the epoch (e.g. Y2K `2000-01-01`) resulted in signed integer underflow, wrapping into a huge `uint32` (~`3841623296`) and generating IDs with timestamps in the year 2136 with a `nil` error.
- Any timestamp after `epochStamp + math.MaxUint32` (> June 19, 2150) overflowed 32 bits back to 2014.

### Changes
- Defined `errTime` sentinel error:
  `errTime = fmt.Errorf("Valid KSUID timestamps are bounded by %s and %s", time.Unix(epochStamp, 0).UTC(), time.Unix(epochStamp+math.MaxUint32, 0).UTC())`
- Validated `u := t.Unix()` in `timeToCorrectedUTCTimestamp(t)`; returns `(0, errTime)` when `u < epochStamp || u > epochStamp+math.MaxUint32`.
- Validated timestamp before acquiring `randMutex` in `NewRandomWithTime(t)` to avoid unnecessary mutex contention and entropy consumption on invalid inputs.
- Propagated `errTime` in `NewRandomWithTime` and `FromParts`. `FromPartsOrNil` naturally returns `Nil`.
- Added `TestFromPartsTimestampBounds` in `ksuid_test.go` covering epoch edge, max-uint32 edge, pre-epoch timestamps (Y2K, 1 sec before epoch, zero `time.Time{}`), post-max timestamps, and payload length precedence.

<!-- campaign_id: oss-hv-pr-500-v1 action_id: act-51aac5d53f7b -->
